### PR TITLE
Comments on show (and some other show fixes)

### DIFF
--- a/app/assets/stylesheets/pages/_show.scss
+++ b/app/assets/stylesheets/pages/_show.scss
@@ -25,7 +25,8 @@
 .text-background {
   background-color: $light-blue;
   padding: 10px;
-  margin-left: 20px;
+  border: 0.5px solid $blue;
+  border-radius: 5px;
 }
 
 .event-name-show {
@@ -80,15 +81,25 @@
   padding: 2px 10px;
   color: white;
 }
+
 .level-orange {
   background: $orange;
   border-radius: 10px;
   padding: 2px 10px;
   color: white;
 }
+
 .level-red {
   background: $red;
   border-radius: 10px;
   padding: 2px 10px;
   color: white;
+}
+
+.smaller-h2 {
+  font-size: 22px;
+}
+
+.smaller-title {
+  font-size: 28px;
 }

--- a/app/assets/stylesheets/pages/_show.scss
+++ b/app/assets/stylesheets/pages/_show.scss
@@ -72,7 +72,7 @@
 .comments {
   border-top: 0.5px solid #E8E8E8;
   margin-top: 20px;
-  padding-top: 10px;
+  padding-top: 20px;
 }
 
 .level-green {

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -168,8 +168,8 @@
               <small class="ml-1"><%= post.created_at.strftime("%a %b %e at %l:%M%p") %></small>
             </i>
           </div>
-          <div>
             <% if policy(post).destroy? %>
+          <div>
               <%= link_to "", post_path(post), method: :delete, data: { confirm: 'Are you sure you want to delete this comment?' }, class: "mr-2 far fa-trash-alt" %>
           </div>
             <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,7 +1,7 @@
 <div class="show-card">
   <div>
     <div class="event-name-show">
-      <h2 class=""><%= @event.name %></h2>
+      <h2 class="smaller-title"><%= @event.name %></h2>
     </div>
     <div class="d-flex justify-content-between event-info-show">
       <div class="d-flex justify-content-between">
@@ -76,10 +76,10 @@
   <div class="d-flex justify-content-between show-card-avatar">
     <div>
       <%= cl_image_tag @event.user.photo.key, class: "img-card-avatar" %>
-      <p class="center-text"><%= @event.user.username %></p>
+      <p class="mt-1 center-text"><%= @event.user.username %></p>
     </div>
     <div>
-      <p class="text-background"><%= @event.description %></p>
+      <p class="ml-3 text-background"><%= @event.description %></p>
     </div>
   </div>
 
@@ -157,7 +157,7 @@
 </div>
 
 <div class="container comments">
-  <h2>Comments</h2>
+  <h2 class="smaller-h2">Ask a question...</h2>
   <div>
     <% @event.posts.each do |post| %>
       <div id="post-<%= post.id  %>">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -14,7 +14,8 @@
           <p class="text-danger ml-2"><span class="level-red"><%= @event.level %></span></p>
         <% end %>
       </div>
-      <div>
+      <div class="d-flex align-content-center">
+        <i class="fas fa-users mr-2 icon-blue pt-1"></i>
         <p> <%= @event.bookings.count %> / <%= @event.capacity %></p>
       </div>
     </div>


### PR DESCRIPTION
<img width="366" alt="Screenshot 2020-12-03 at 12 35 22" src="https://user-images.githubusercontent.com/37460248/101013171-2d6c3500-3564-11eb-82d3-8d365ce739d3.png">

- [x] Added icon for capacity

- [x] Made title size smaller

- [x] Added a border around the event description

<img width="360" alt="Screenshot 2020-12-03 at 12 25 13" src="https://user-images.githubusercontent.com/37460248/101013177-2fce8f00-3564-11eb-9d64-ac893312618a.png">

- [x] Changed comments text

- [x] Made all comments appear on one line (no matter who makes them)

- [x] Added a border around the comment
